### PR TITLE
画像URL取得ロジックの簡素化

### DIFF
--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -53,14 +53,6 @@ class BaseController extends Controller
     }
 
     /**
-     * 環境に応じたストレージディスク名を返す
-     */
-    protected function storageDisk(): string
-    {
-        return app()->environment('local') ? 'local_img' : 's3';
-    }
-
-    /**
      * 画像をリサイズ・圧縮し、1MB以内に収める
      * @param \Illuminate\Http\UploadedFile $uploadedFile
      * @return string バイナリデータ

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -346,11 +346,11 @@ class BookController extends BaseController
 
         // 画像ファイルアップロード（圧縮処理を追加）
         $compressedImage = $this->processAndCompressImage($thumbnail);
-        Storage::disk($this->storageDisk())->put('thumbnails/' . $fileName, $compressedImage);
+        Storage::disk(image_storage_disk())->put('thumbnails/' . $fileName, $compressedImage);
 
         // 古いサムネイルファイル削除
         if ($oldThumbnail) {
-            Storage::disk($this->storageDisk())->delete('thumbnails/' . $oldThumbnail);
+            Storage::disk(image_storage_disk())->delete('thumbnails/' . $oldThumbnail);
         }
 
         return response()->json(['file_name' => $fileName]);

--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -106,7 +106,7 @@ class ImageController extends BaseController
         try {
             // 画像をリサイズ・圧縮してストレージにアップロード
             $imageData = $this->processAndCompressImage($request->file('image'));
-            Storage::disk($this->storageDisk())->put('images/' . $fileName, $imageData);
+            Storage::disk(image_storage_disk())->put('images/' . $fileName, $imageData);
         } catch (\Exception $e) {
             // エラーが発生した場合、DBからレコードを削除
             $result->delete();
@@ -194,7 +194,7 @@ class ImageController extends BaseController
 
         try {
             // 旧画像ファイル削除
-            Storage::disk($this->storageDisk())->delete('images/' . $oldFileName);
+            Storage::disk(image_storage_disk())->delete('images/' . $oldFileName);
         } catch (\Exception $e) {
             // 画像ファイルの削除に失敗した場合はログに記録し、中断
             logger()->error('画像ファイルの削除に失敗', [
@@ -207,7 +207,7 @@ class ImageController extends BaseController
         try {
             // 画像をリサイズ・圧縮してストレージにアップロード
             $imageData = $this->processAndCompressImage($imageFile);
-            Storage::disk($this->storageDisk())->put('images/' . $fileName, $imageData);
+            Storage::disk(image_storage_disk())->put('images/' . $fileName, $imageData);
             // DB更新
             $image->update(['file_name' => $fileName]);
         } catch (\Exception $e) {
@@ -244,9 +244,9 @@ class ImageController extends BaseController
     {
         $fileName = $image->getRawOriginal('file_name');
 
-        if(Storage::disk($this->storageDisk())->exists('images/' . $fileName)) {
+        if(Storage::disk(image_storage_disk())->exists('images/' . $fileName)) {
             // 画像ファイル削除
-            Storage::disk($this->storageDisk())->delete('images/' . $fileName);
+            Storage::disk(image_storage_disk())->delete('images/' . $fileName);
         } else {
             logger()->warning('画像ファイルが存在しません', ['file_name' => $fileName]);
         }

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Storage;
 
 class Book extends BaseModel
 {
@@ -35,10 +36,7 @@ class Book extends BaseModel
     public function getThumbnailAttribute($value)
     {
         $file = $value ?: 'no-image.png';
-        if (app()->environment('local')) {
-            return '/img/thumbnails/' . $file;
-        }
-        return config('app.img_endpoint') . '/thumbnails/' . $file;
+        return Storage::disk(image_storage_disk())->url('thumbnails/' . $file);
     }
 
     public function user()

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
 
 class Image extends BaseModel
 {
@@ -25,9 +26,6 @@ class Image extends BaseModel
     public function getFileNameAttribute($value)
     {
         $file = $value ?: 'no-image.png';
-        if (app()->environment('local')) {
-            return '/img/images/' . $file;
-        }
-        return config('app.img_endpoint') . '/images/' . $file;
+        return Storage::disk(image_storage_disk())->url('images/' . $file);
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,11 @@
+<?php
+
+if (!function_exists('image_storage_disk')) {
+    /**
+     * 画像用のストレージディスク名を返す
+     */
+    function image_storage_disk(): string
+    {
+        return app()->environment('local') ? 'local_img' : 's3_img';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "phpunit/phpunit": "^11.0.1"
     },
     "autoload": {
+        "files": [
+            "app/helpers.php"
+        ],
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -65,6 +65,18 @@ return [
             'throw' => true,
         ],
 
+        's3_img' => [
+            'driver' => 's3',
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'region' => env('AWS_DEFAULT_REGION'),
+            'bucket' => env('AWS_BUCKET'),
+            'url' => env('IMG_ENDPOINT'),
+            'endpoint' => env('AWS_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw' => true,
+        ],
+
     ],
 
     /*


### PR DESCRIPTION
## 変更内容

- `app/helpers.php` を新規作成し、`image_storage_disk()` グローバルヘルパーを追加
- `composer.json` に `app/helpers.php` の autoload 登録を追加
- `config/filesystems.php` に `s3_img` ディスクを追加（`IMG_ENDPOINT` を URL として使用）
- `BaseController::storageDisk()` を `image_storage_disk()` に委譲するよう変更
- `Book::getThumbnailAttribute()` と `Image::getFileNameAttribute()` の環境判定 `if` 文を除去し、`Storage::disk(image_storage_disk())->url()` に統一

## ポイント

`image_storage_disk()` をヘルパー化することで、Controller だけでなく Model からも再利用可能になった。ローカル環境では `local_img`、本番環境では `s3_img` ディスクを使用し、`Storage::url()` でURLを生成するため、環境ごとの分岐が不要になった。

Close #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 別途人力対応
- BaseContollerのstorageDisk関数が残ってしまったので削除（storageDisk使用箇所はimage_storage_diskを使うように修正）。